### PR TITLE
Broaden README use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,21 @@ Run `bundle install`.
 Define new helper in `app/helpers/application_helper.rb`:
 
 ```ruby
-def outdated_browser?
+def supported_browser?
   @browsers ||= JSON.parse(File.read(PATH_TO_BROWSERS_JSON))
   matcher = BrowserslistUseragent::Match.new(@browsers, request.user_agent)
-  matcher.browser? && !matcher.version?(allow_higher: true)
+  matcher.browser? && matcher.version?(allow_higher: true)
 end
 ```
 
 ### 4. Use helper in template
 
-Put some text for user with outdated browser in `app/views/layout` and add this check in application layout:
+Put a warning message for users with an unsupported browser in `app/views/layouts/_unsupported_browser_warning` and add this check in application layout:
 
 ```haml
 body
-  - if outdated_browser?
-    render 'outdated_browser_warning'
+  - if !supported_browser?
+    render 'layouts/unsupported_browser_warning'
 ```
 
 ### Separated projects


### PR DESCRIPTION
This reverts back to the `modern_browser?` intent outlined in the README
before @ai's changes in PR #4.

In doing so it shows an error unless the browser is matched explicitly.

For example in an app that doesn't support any version of IE, a message
will _always_ be shown.