### PR TITLE
Support detecting desktop Safari

### DIFF
--- a/lib/browserslist_useragent/resolver.rb
+++ b/lib/browserslist_useragent/resolver.rb
@@ -17,9 +17,9 @@ module BrowserslistUseragent
       family = agent.family
       version = VersionNormalizer.new(agent.version.to_s).call
 
-      # Case A: For Safari, Chrome and others browsers
+      # Case A: For Safari, Chrome and others browsers on iOS
       # that report as Safari after stripping tags
-      family = 'iOS' if agent.family.include?('Safari')
+      family = 'iOS' if agent.family.include?('Safari') && agent.os.family == 'iOS'
 
       # Case B: The browser on iOS didn't report as safari,
       # so we use the iOS version as a proxy to the browser

--- a/spec/browserslist_useragent/resolver_spec.rb
+++ b/spec/browserslist_useragent/resolver_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe BrowserslistUseragent::Resolver do
       ).to eq(family: 'iOS', version: '8.3.0')
     end
 
+    it 'desktop safari on OS X' do
+      expect(
+        resolve_user_agent(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1.0 Safari/603.1.30'
+        )
+      ).to eq(family: 'Safari', version: '10.1.0')
+    end
+
     it 'resolves IE/Edge properly' do
       # explorer
       expect(


### PR DESCRIPTION
It looks like there was an omission in porting https://github.com/browserslist/browserslist-useragent/blob/1cbab42d134df76aea5294edfacddd243fe4832f/index.js#L42

Namely, we only want to report that the family is iOS if the agent includes `Safari` _and_ we are actually on iOS.

Fixes #6 