### PR TITLE
Improve performance of Resolver

### DIFF
--- a/lib/browserslist_useragent/resolver.rb
+++ b/lib/browserslist_useragent/resolver.rb
@@ -12,7 +12,7 @@ module BrowserslistUseragent
     end
 
     def call
-      agent = UserAgentParser.parse(user_agent_string)
+      agent = self.class.user_agent_parser.parse(user_agent_string)
 
       family = agent.family
       version = VersionNormalizer.new(agent.version.to_s).call
@@ -47,6 +47,10 @@ module BrowserslistUseragent
       family = 'UCAndroid' if agent.family == 'UC Browser'
 
       { family: family, version: version }
+    end
+
+    def self.user_agent_parser
+      @parser ||= UserAgentParser::Parser.new
     end
   end
 end


### PR DESCRIPTION
By using UserAgentParser's recommended method of caching the Parser instance, we can prevent reading from a file each time `.browser?`/`.version?` is called. This results in upto a 50x speedup for `browser?` calls.

```
Benchmark.ips do |x|
  match = BrowserslistUseragent::Match.new([], "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36")
  x.report{ match.browser? }
end
```
*Before*
```
Warming up --------------------------------------
                         3.000  i/100ms
Calculating -------------------------------------
                         31.386  (±12.7%) i/s -    156.000  in   5.059809s
```
*After*
```
Warming up --------------------------------------
                       158.000  i/100ms
Calculating -------------------------------------
                          1.668k (± 4.4%) i/s -      8.374k in   5.031321s
```