### PR TITLE
Support detecting headless Chrome

### DIFF
--- a/lib/browserslist_useragent/resolver.rb
+++ b/lib/browserslist_useragent/resolver.rb
@@ -39,7 +39,7 @@ module BrowserslistUseragent
       # In this case, we proxy to the desktop version
       # @see https://github.com/Fyrd/caniuse/issues/3518
       family = 'Chrome' if agent.family.include?('Chrome Mobile')
-
+      family = 'Chrome' if agent.family == 'HeadlessChrome'
       family = 'Firefox' if agent.family == 'Firefox Mobile'
       family = 'Explorer' if agent.family == 'IE'
       family = 'ExplorerMobile' if agent.family == 'IE Mobile'

--- a/spec/browserslist_useragent/resolver_spec.rb
+++ b/spec/browserslist_useragent/resolver_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe BrowserslistUseragent::Resolver do
         )
       ).to eq(family: 'Chrome', version: '41.0.228')
 
+      # headless
+      expect(
+        resolve_user_agent(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/60.0.3112.50 Safari/537.36'
+        )
+      ).to eq(family: 'Chrome', version: '60.0.3112')
+
       # android
       expect(
         resolve_user_agent(


### PR DESCRIPTION
I think it makes sense to consider HeadlessChrome Chrome in the same way that Mobile Chrome is considered Chrome.

We're running into HeadlessChrome being identified as a separate family for our integration tests and have to work around without this change.