### PR TITLE
[No merge] added edge mobile as family with specs

### DIFF
--- a/lib/browserslist_useragent/resolver.rb
+++ b/lib/browserslist_useragent/resolver.rb
@@ -41,6 +41,7 @@ module BrowserslistUseragent
       family = 'Chrome' if agent.family.include?('Chrome Mobile')
       family = 'Chrome' if agent.family == 'HeadlessChrome'
       family = 'Firefox' if agent.family == 'Firefox Mobile'
+      family = 'Edge' if agent.family == 'Edge Mobile'
       family = 'Explorer' if agent.family == 'IE'
       family = 'ExplorerMobile' if agent.family == 'IE Mobile'
       family = 'QQAndroid' if agent.family == 'QQ Browser Mobile'

--- a/spec/browserslist_useragent/match_spec.rb
+++ b/spec/browserslist_useragent/match_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BrowserslistUseragent::Match do
     [
       'firefox 59', 'firefox 58', 'chrome 64', 'chrome 65',
       'ie 10', 'and_uc 11.8', 'android 4.4.3-4.4.4',
-      'ios_saf 11.3', 'ios_saf 11.0-11.2'
+      'ios_saf 11.3', 'ios_saf 11.0-11.2', 'edge 83'
     ]
   end
 
@@ -27,6 +27,12 @@ RSpec.describe BrowserslistUseragent::Match do
 
     context 'when family is Chrome' do
       let(:user_agent) { { family: 'Chrome' } }
+
+      it { expect(matcher).to be_browser }
+    end
+
+    context 'when family is Edge' do
+      let(:user_agent) { { family: 'Edge' } }
 
       it { expect(matcher).to be_browser }
     end

--- a/spec/browserslist_useragent/resolver_spec.rb
+++ b/spec/browserslist_useragent/resolver_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe BrowserslistUseragent::Resolver do
         )
       ).to eq(family: 'ExplorerMobile', version: '10.0.0')
 
+      # edge mobile
+      expect(
+        resolve_user_agent(
+          'Mozilla/5.0 (Linux; Android 10; LYA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 EdgA/45.07.4.5054'
+        )
+      ).to eq(family: 'Edge', version: '45.07.4')
+
       # edge
       expect(
         resolve_user_agent(


### PR DESCRIPTION
As edge is based on chromium now we also have edge mobile on Android etc.

I think mapping Edge Mobile to Edge is not really correct since the versions are not equal on desktop and mobile (85.0.564.41 
 vs 45.07.2.5057 as of now). This is also not handled by browserslist itself at the moment (https://github.com/browserslist/browserslist/issues/493).

Also the Edge mobile version is not a valid Semantic Version which causes `Semantic::Version.new('45.07.4')` to crash.